### PR TITLE
make it possible to use multiple TinyMCE instances on one page

### DIFF
--- a/copy_this/modules/hdi/hdi-tinymce/views/tinymce.tpl
+++ b/copy_this/modules/hdi/hdi-tinymce/views/tinymce.tpl
@@ -3,7 +3,7 @@
     var tinyMCE = null;
     function copyLongDescFromTinyMCE(sIdent)
     {
-        var editor = tinyMCE.activeEditor;
+        var editor = tinyMCE.get("editor_" + sIdent);
         if (editor && editor.isHidden() !== true)
         {
             var content = editor.getContent({format : 'raw'});


### PR DESCRIPTION
Previously, it was not possible to use multiple instances of TinyMCE on one page, since the function _copyLongDescFromTinyMCE_ only used the value of the active editor instance. This lead to saving the same text multiple times and losing the input in all other editor instances.

This fix evaluates each editor instance separately by addressing them with their DOM id, thus making it possible to use as many TinyMCE instances per page as wanted.
